### PR TITLE
Expose Composio connector diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ OPENAI_API_KEY=""
 # Clé API Composio
 COMPOSIO_API_KEY=""
 
+# Jeton du bot Telegram (optionnel, requis pour les tests grandeur nature)
+TELEGRAM_BOT_TOKEN=""
+
 # Modèle par défaut
 DEFAULT_MODEL="gpt-4o-mini"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Clé API OpenAI pour ChatGPT
+OPENAI_API_KEY=""
+
+# Clé API Composio
+COMPOSIO_API_KEY=""
+
+# Modèle par défaut
+DEFAULT_MODEL="gpt-4o-mini"

--- a/README.md
+++ b/README.md
@@ -108,9 +108,24 @@ La même information est également exposée via `GET /mcp/v1/metadata` pour des
 
 ## Tests
 
+Exécutez la suite depuis la racine du dépôt :
+
 ```bash
 pytest
 ```
+
+Sous Windows, l'équivalent est :
+
+```powershell
+py -m pytest
+```
+
+Les tests ne se contentent pas de vérifier que les modules se chargent : ils
+simulent différentes réponses de l'API Composio pour confirmer que
+`ComposioClient.list_available_tools()` signale correctement l'accès aux
+connecteurs et aux actions attendus. Une fois la suite terminée, vous devez
+obtenir un résumé `1 passed` ou `2 passed` selon les options activées, sans
+erreurs.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
-# Infinity_lookalike
+# Infinity MCP Customer Service Agent
+
+Ce dépôt contient un serveur [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) qui expose un agent IA de relation clientèle multicanal. L'agent combine un modèle de langage (ChatGPT via l'API OpenAI) et la plateforme d'orchestration Composio pour enrichir les réponses avec du contexte client.
+
+## Fonctionnalités
+
+- Support natif de WhatsApp, LinkedIn, Gmail, Outlook et Instagram via Composio.
+- Intégration optionnelle avec Composio pour récupérer des connaissances et signaux client.
+- Génération de réponses naturelles grâce aux modèles ChatGPT.
+- API MCP simple (`/mcp/v1/execute`) pour piloter l'agent depuis différents connecteurs.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Configuration
+
+Dupliquez le fichier `.env.example` en `.env` puis renseignez les clés API nécessaires :
+
+```env
+OPENAI_API_KEY="sk-..."
+COMPOSIO_API_KEY="cmpo-..."
+```
+
+Les clés sont optionnelles : sans elles, le serveur fonctionne en mode simulation (réponses statiques et contexte synthétique), ce qui est utile pour le développement local.
+
+## Démarrage du serveur
+
+```bash
+uvicorn mcp_customer_service.server:build_app --factory --host 0.0.0.0 --port 8000
+```
+
+### Endpoints principaux
+
+- `GET /health` : vérifie l'état du serveur.
+- `GET /mcp/v1/metadata` : décrit les capacités exposées.
+- `POST /mcp/v1/execute` : exécute la commande `customer-agent.reply` avec une charge utile décrivant le message client.
+
+Exemple de requête (conversation WhatsApp) :
+
+```json
+{
+  "command": "customer-agent.reply",
+  "payload": {
+    "channel": "whatsapp",
+    "customer_id": "12345",
+    "message": "Je souhaite suivre ma commande",
+    "history": [],
+    "metadata": {
+      "whatsapp_number": "+33600000000",
+      "sentiment": "neutral",
+      "urgency": "low"
+    }
+  }
+}
+```
+
+### Métadonnées nécessaires par canal
+
+Pour permettre à l'agent d'envoyer la réponse via Composio, fournissez l'identifiant adéquat dans `payload.metadata` :
+
+| Canal | Clé(s) attendue(s) | Description |
+| --- | --- | --- |
+| `whatsapp` | `whatsapp_number` ou `phone_number` | Numéro international WhatsApp du client. |
+| `linkedin` | `linkedin_profile` ou `profile_url` | URL du profil LinkedIn du client. |
+| `gmail` | `gmail_address` ou `email` | Adresse Gmail du destinataire. |
+| `outlook` | `outlook_address` ou `email` | Adresse Outlook/Exchange du destinataire. |
+| `instagram` | `instagram_handle` ou `username` | Pseudonyme Instagram (sans `@`). |
+
+Les canaux email (`gmail`, `outlook`) peuvent également inclure `subject` pour préciser l'objet du message.
+
+### Vérifier l'accès aux connecteurs Composio
+
+Pour confirmer que l'agent peut réellement envoyer des messages sur chaque canal, interrogez l'endpoint dédié :
+
+```bash
+curl http://localhost:8000/mcp/v1/connectors | jq
+```
+
+La réponse indique le mode (`live` ou `simulated`) et, pour chaque canal, si le connecteur et l'action Composio sont accessibles. Exemple de sortie :
+
+```json
+{
+  "mode": "live",
+  "connectors": [
+    {
+      "channel": "whatsapp",
+      "connector": "whatsapp",
+      "action": "send_message",
+      "available": true
+    },
+    {
+      "channel": "linkedin",
+      "connector": "linkedin",
+      "action": "send_message",
+      "available": false,
+      "reason": "Connecteur introuvable dans l'espace Composio"
+    }
+  ]
+}
+```
+
+La même information est également exposée via `GET /mcp/v1/metadata` pour des vérifications rapides côté client MCP.
+
+## Tests
+
+```bash
+pytest
+```
+
+## Licence
+
+MIT

--- a/README.md
+++ b/README.md
@@ -127,6 +127,48 @@ connecteurs et aux actions attendus. Une fois la suite terminée, vous devez
 obtenir un résumé `1 passed` ou `2 passed` selon les options activées, sans
 erreurs.
 
+## Tester l'agent en conditions réelles avec Telegram
+
+Pour discuter avec l'agent et piloter les connexions Composio utilisateur par
+utilisateur, vous pouvez lancer le bot Telegram inclus.
+
+1. Créez un bot via [@BotFather](https://t.me/BotFather) et récupérez le jeton
+   d'accès, puis renseignez la variable `TELEGRAM_BOT_TOKEN` dans votre fichier
+   `.env`.
+2. Installez les dépendances (voir section *Installation*) puis lancez le bot :
+
+   ```bash
+   python -m mcp_customer_service.telegram_bot
+   ```
+
+   ou créez un petit script :
+
+   ```python
+   from mcp_customer_service import TelegramCustomerAgentBot
+   from mcp_customer_service.config import get_settings
+
+   settings = get_settings()
+   bot = TelegramCustomerAgentBot(token=settings.telegram_bot_token)
+   bot.run()
+   ```
+
+3. Depuis Telegram, envoyez `/start` pour découvrir les commandes :
+   - `/channel <canal>` pour choisir le canal simulé (WhatsApp, LinkedIn,
+     Gmail, Outlook, Instagram).
+   - `/connect <canal>` pour générer un lien Composio OAuth permettant à
+     l'utilisateur de connecter son propre compte (Google, Meta, etc.).
+   - `/installations` pour vérifier les connecteurs réellement associés au
+     compte Composio de l'utilisateur.
+   - `/setmeta <clé> <valeur>` pour fournir des identifiants précis (adresse
+     email, numéro WhatsApp, profil LinkedIn…) utilisés lors de l'envoi.
+
+Le bot réutilise exactement le même orchestrateur que l'API MCP : chaque
+message envoyé depuis Telegram est transformé en `CustomerPayload`, passé au LLM
+et, si les identifiants sont disponibles, la réponse est envoyée via Composio
+sur le canal sélectionné. En absence de clés API ou de connecteurs installés,
+le bot fonctionne en mode simulation et indique clairement l'état des
+installations.
+
 ## Licence
 
 MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "mcp-customer-service"
+version = "0.1.0"
+description = "Serveur MCP pour agent IA de relation client multicanal basé sur ChatGPT et Composio"
+authors = [
+  { name = "Infinity Lookalike", email = "contact@example.com" }
+]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn>=0.23",
+  "pydantic>=2.6",
+  "python-dotenv>=1.0",
+  "openai>=1.10",
+  "mcp>=0.1",
+  "composio>=0.3"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "pytest-asyncio>=0.23"
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
   "python-dotenv>=1.0",
   "openai>=1.10",
   "mcp>=0.1",
-  "composio>=0.3"
+  "composio>=0.3",
+  "python-telegram-bot>=20.6"
 ]
 
 [project.optional-dependencies]

--- a/src/mcp_customer_service/__init__.py
+++ b/src/mcp_customer_service/__init__.py
@@ -1,0 +1,5 @@
+"""Serveur MCP pour agent IA de relation client multicanal."""
+
+from .server import build_app
+
+__all__ = ["build_app"]

--- a/src/mcp_customer_service/__init__.py
+++ b/src/mcp_customer_service/__init__.py
@@ -1,5 +1,6 @@
 """Serveur MCP pour agent IA de relation client multicanal."""
 
 from .server import build_app
+from .telegram_bot import TelegramCustomerAgentBot
 
-__all__ = ["build_app"]
+__all__ = ["build_app", "TelegramCustomerAgentBot"]

--- a/src/mcp_customer_service/channels.py
+++ b/src/mcp_customer_service/channels.py
@@ -23,7 +23,9 @@ class ConversationMessage(BaseModel):
 
     role: str
     content: str
-    timestamp: dt.datetime = Field(default_factory=dt.datetime.utcnow)
+    timestamp: dt.datetime = Field(
+        default_factory=lambda: dt.datetime.now(dt.timezone.utc)
+    )
 
 
 class CustomerPayload(BaseModel):

--- a/src/mcp_customer_service/channels.py
+++ b/src/mcp_customer_service/channels.py
@@ -1,0 +1,86 @@
+"""Gestion des messages multi-canaux pour l'agent."""
+from __future__ import annotations
+
+import datetime as dt
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SupportChannel(str, Enum):
+    """Enumération des canaux supportés via Composio."""
+
+    whatsapp = "whatsapp"
+    linkedin = "linkedin"
+    gmail = "gmail"
+    outlook = "outlook"
+    instagram = "instagram"
+
+
+class ConversationMessage(BaseModel):
+    """Représente un message dans l'historique de la conversation."""
+
+    role: str
+    content: str
+    timestamp: dt.datetime = Field(default_factory=dt.datetime.utcnow)
+
+
+class CustomerPayload(BaseModel):
+    """Requête provenant d'un canal client."""
+
+    channel: SupportChannel
+    customer_id: str
+    thread_id: Optional[str] = None
+    message: str
+    history: List[ConversationMessage] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentReply(BaseModel):
+    """Réponse formatée par l'agent."""
+
+    channel: SupportChannel
+    reply: str
+    actions: List[str] = Field(default_factory=list)
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+
+def build_llm_messages(payload: CustomerPayload, insights: Iterable[str]) -> List[dict]:
+    """Transforme la requête en format compatible avec OpenAI."""
+
+    messages: List[dict] = [
+        {
+            "role": "system",
+            "content": (
+                "Tu es Infinity, un agent IA de relation client multicanal "
+                "capable de répondre sur WhatsApp, LinkedIn, Gmail, Outlook et "
+                "Instagram. Sois empathique, concis et propose des actions "
+                "concrètes adaptées au canal. Utilise les informations "
+                "contextuelles pour personnaliser la réponse."
+            ),
+        }
+    ]
+
+    for hist in payload.history[-5:]:
+        messages.append({"role": hist.role, "content": hist.content})
+
+    if insights:
+        messages.append(
+            {
+                "role": "system",
+                "content": "Informations contextuelles: " + " | ".join(insights),
+            }
+        )
+
+    messages.append({"role": "user", "content": payload.message})
+    return messages
+
+
+__all__ = [
+    "SupportChannel",
+    "ConversationMessage",
+    "CustomerPayload",
+    "AgentReply",
+    "build_llm_messages",
+]

--- a/src/mcp_customer_service/composio_client.py
+++ b/src/mcp_customer_service/composio_client.py
@@ -195,6 +195,207 @@ class ComposioClient:
         reason = "; ".join(dict.fromkeys(issues)) if issues else None
         return available, reason
 
+    # ------------------------------------------------------------------
+    # Gestion des installations utilisateurs
+    def generate_installation_link(
+        self,
+        channel: SupportChannel,
+        external_user_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Crée un lien d'installation OAuth pour un utilisateur final.
+
+        Lorsque Composio n'est pas initialisé, un lien simulé est retourné pour
+        permettre les tests manuels sans dépendances externes.
+        """
+
+        connector_spec = self.CHANNEL_CONNECTORS.get(channel)
+        if connector_spec is None:
+            return {
+                "status": "unsupported",
+                "reason": f"Canal {channel.value} non configuré",
+            }
+
+        if not self._client:
+            return {
+                "status": "simulated",
+                "channel": channel.value,
+                "url": f"https://example.com/composio/install/{channel.value}",
+            }
+
+        installations_client = self._resolve_installations_client()
+        if installations_client is None:
+            return {
+                "status": "error",
+                "channel": channel.value,
+                "reason": "Le SDK Composio ne fournit pas d'API d'installation",
+            }
+
+        request_payload = self._build_installation_payload(
+            connector_spec["connector"], external_user_id
+        )
+
+        for method_name in (
+            "create_installation_link",
+            "create_link",
+            "create",
+            "generate_link",
+            "generate",
+        ):
+            method = getattr(installations_client, method_name, None)
+            if callable(method):
+                try:
+                    result = method(**request_payload)
+                    response = self._normalize_installation_response(result)
+                    response.setdefault("status", "live")
+                    response.setdefault("channel", channel.value)
+                    return response
+                except TypeError:
+                    # Essaye sans l'identifiant externe si la signature ne le supporte pas
+                    trimmed_payload = {
+                        key: value
+                        for key, value in request_payload.items()
+                        if key != "external_user_id"
+                    }
+                    try:
+                        result = method(**trimmed_payload)
+                        response = self._normalize_installation_response(result)
+                        response.setdefault("status", "live")
+                        response.setdefault("channel", channel.value)
+                        return response
+                    except Exception as exc:  # pragma: no cover - dépend du SDK
+                        return {
+                            "status": "error",
+                            "channel": channel.value,
+                            "reason": str(exc),
+                        }
+                except Exception as exc:  # pragma: no cover - dépend du SDK
+                    return {
+                        "status": "error",
+                        "channel": channel.value,
+                        "reason": str(exc),
+                    }
+
+        return {
+            "status": "error",
+            "channel": channel.value,
+            "reason": "Aucune méthode compatible pour générer un lien",
+        }
+
+    def list_user_installations(
+        self, external_user_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Répertorie les installations existantes pour un utilisateur final."""
+
+        if not self._client:
+            return {
+                "status": "simulated",
+                "installations": [],
+            }
+
+        installations_client = self._resolve_installations_client()
+        if installations_client is None:
+            return {
+                "status": "error",
+                "reason": "Le SDK Composio ne fournit pas d'API d'installation",
+                "installations": [],
+            }
+
+        method = getattr(installations_client, "list", None)
+        if not callable(method):
+            return {
+                "status": "error",
+                "reason": "Méthode list() indisponible sur installations",
+                "installations": [],
+            }
+
+        try:
+            if external_user_id is not None:
+                result = method(external_user_id=external_user_id)
+            else:
+                result = method()
+        except TypeError:
+            # Certains SDK utilisent une signature différente
+            result = method()
+        except Exception as exc:  # pragma: no cover - dépend du SDK
+            return {
+                "status": "error",
+                "reason": str(exc),
+                "installations": [],
+            }
+
+        installations = self._normalize_installations_list(result)
+        return {
+            "status": "live",
+            "installations": installations,
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers internes
+    def _resolve_installations_client(self) -> Any:
+        """Récupère le client gérant les installations utilisateurs."""
+
+        if not self._client:
+            return None
+
+        for attr in ("installations", "connections", "integrations", "oauth"):
+            candidate = getattr(self._client, attr, None)
+            if candidate is not None:
+                return candidate
+        return None
+
+    @staticmethod
+    def _build_installation_payload(
+        connector_slug: str, external_user_id: Optional[str]
+    ) -> Dict[str, Any]:
+        payload = {"connector": connector_slug}
+        if external_user_id:
+            payload.update(
+                {
+                    "external_user_id": external_user_id,
+                    "metadata": {"external_user_id": external_user_id},
+                }
+            )
+        return payload
+
+    @staticmethod
+    def _normalize_installation_response(result: Any) -> Dict[str, Any]:
+        """Harmonise la réponse en dictionnaire simple."""
+
+        if isinstance(result, dict):
+            response = dict(result)
+        elif hasattr(result, "__dict__"):
+            response = dict(result.__dict__)
+        else:
+            response = {"raw": result}
+
+        url = None
+        for key in ("url", "authorization_url", "auth_url", "link"):
+            value = response.get(key)
+            if isinstance(value, str):
+                url = value
+                break
+        if url is None and isinstance(result, str):
+            url = result
+
+        if url:
+            response["url"] = url
+
+        return response
+
+    @staticmethod
+    def _normalize_installations_list(result: Any) -> List[Dict[str, Any]]:
+        """Normalise une liste d'installations utilisateur renvoyée par Composio."""
+
+        normalized: List[Dict[str, Any]] = []
+        for item in ComposioClient._normalize_collection(result):
+            if isinstance(item, dict):
+                normalized.append(item)
+            elif hasattr(item, "__dict__"):
+                normalized.append(dict(item.__dict__))
+            else:
+                normalized.append({"value": item})
+        return normalized
+
     @staticmethod
     def _entry_in_collection(expected: str, collection: Any, keys: tuple[str, ...]) -> bool:
         """Détermine si une valeur correspondante est présente dans une collection."""

--- a/src/mcp_customer_service/composio_client.py
+++ b/src/mcp_customer_service/composio_client.py
@@ -1,0 +1,319 @@
+"""Intégration avec Composio pour enrichir le contexte client et distribuer les réponses."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .config import Settings, get_settings
+from .channels import SupportChannel
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - dépendance optionnelle
+    from composio import Composio
+except Exception:  # pragma: no cover - gestion douce des imports
+    Composio = None  # type: ignore[assignment]
+
+
+class ComposioClient:
+    """Client léger autour du SDK Composio."""
+
+    CHANNEL_CONNECTORS: Dict[SupportChannel, Dict[str, str]] = {
+        SupportChannel.whatsapp: {
+            "connector": "whatsapp",
+            "action": "send_message",
+            "handle_param": "phone_number",
+        },
+        SupportChannel.linkedin: {
+            "connector": "linkedin",
+            "action": "send_message",
+            "handle_param": "profile_url",
+        },
+        SupportChannel.gmail: {
+            "connector": "gmail",
+            "action": "send_email",
+            "handle_param": "to",
+        },
+        SupportChannel.outlook: {
+            "connector": "outlook",
+            "action": "send_email",
+            "handle_param": "to",
+        },
+        SupportChannel.instagram: {
+            "connector": "instagram",
+            "action": "send_dm",
+            "handle_param": "username",
+        },
+    }
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._client = None
+        if not self.settings.composio_api_key or Composio is None:
+            if Composio is None:
+                logger.warning(
+                    "Le package composio n'est pas installé. Retour en mode simulation."
+                )
+            else:
+                logger.warning(
+                    "Aucune clé API Composio détectée. Utilisation d'un mode simulé."
+                )
+        else:
+            try:
+                self._client = Composio(api_key=self.settings.composio_api_key)
+            except Exception as exc:  # pragma: no cover
+                logger.error("Impossible d'initialiser Composio: %s", exc)
+                self._client = None
+
+    # ---------------------------------------------------------------------
+    # Découverte de contexte
+    def enrich_context(self, channel: str, customer_id: str, message: str) -> Dict[str, Any]:
+        """Retourne des informations supplémentaires liées au client."""
+
+        if not self._client:
+            logger.debug(
+                "Enrichissement simulé pour customer_id=%s channel=%s", customer_id, channel
+            )
+            return {
+                "customer_id": customer_id,
+                "channel": channel,
+                "insights": [
+                    "Client premium avec historique d'achats récurrents",
+                    "Dernière interaction il y a 5 jours",
+                ],
+                "knowledge_base_matches": [],
+            }
+
+        logger.debug(
+            "Interrogation de Composio pour customer_id=%s channel=%s", customer_id, channel
+        )
+        knowledge_hits: List[Dict[str, Any]] = []
+        try:
+            knowledge_hits = self._client.knowledge.search(
+                query=message,
+                metadata={"channel": channel, "customer_id": customer_id},
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.error("Erreur Composio lors de la recherche de connaissances: %s", exc)
+
+        return {
+            "customer_id": customer_id,
+            "channel": channel,
+            "insights": self._build_insights(knowledge_hits),
+            "knowledge_base_matches": knowledge_hits,
+        }
+
+    @staticmethod
+    def _build_insights(knowledge_hits: List[Dict[str, Any]]) -> List[str]:
+        """Synthétise les informations renvoyées par Composio."""
+
+        insights: List[str] = []
+        for hit in knowledge_hits:
+            title = hit.get("title")
+            summary = hit.get("summary") or hit.get("content")
+            if title and summary:
+                insights.append(f"{title}: {summary}")
+            elif title:
+                insights.append(title)
+            elif summary:
+                insights.append(summary)
+        return insights
+
+    # ------------------------------------------------------------------
+    # Découverte des connecteurs et actions disponibles
+    def list_available_tools(self) -> Dict[str, Any]:
+        """Inspecte Composio pour vérifier l'accès aux connecteurs configurés."""
+
+        mode = "live" if self._client else "simulated"
+        status: List[Dict[str, Any]] = []
+        for channel, spec in self.CHANNEL_CONNECTORS.items():
+            channel_status: Dict[str, Any] = {
+                "channel": channel.value,
+                "connector": spec["connector"],
+                "action": spec["action"],
+            }
+            if not self._client:
+                channel_status.update(
+                    {
+                        "available": False,
+                        "reason": "Mode simulation: clé API ou SDK Composio manquant.",
+                    }
+                )
+            else:
+                available, reason = self._inspect_connector(spec["connector"], spec["action"])
+                channel_status["available"] = available
+                if reason:
+                    channel_status["reason"] = reason
+            status.append(channel_status)
+
+        return {"mode": mode, "connectors": status}
+
+    def _inspect_connector(self, connector_slug: str, action_name: str) -> tuple[bool, Optional[str]]:
+        """Valide que le connecteur et l'action sont exposés par Composio."""
+
+        issues: List[str] = []
+        connector_found = False
+        action_found = False
+
+        if not self._client:
+            return False, "Client Composio inactif"
+
+        # Vérifie la présence du connecteur
+        connectors_client = getattr(self._client, "connectors", None)
+        if connectors_client and hasattr(connectors_client, "list"):
+            try:
+                connectors = connectors_client.list()
+                connector_found = self._entry_in_collection(
+                    connector_slug, connectors, keys=("slug", "name", "connector", "id")
+                )
+                if not connector_found:
+                    issues.append("Connecteur introuvable dans l'espace Composio")
+            except Exception as exc:  # pragma: no cover - dépend des implémentations SDK
+                issues.append(f"Impossible d'interroger les connecteurs: {exc}")
+        else:
+            issues.append("La méthode connectors.list() n'est pas disponible")
+
+        # Vérifie la présence de l'action
+        actions_client = getattr(self._client, "actions", None)
+        if actions_client and hasattr(actions_client, "list"):
+            try:
+                try:
+                    actions = actions_client.list(connector=connector_slug)
+                except TypeError:
+                    actions = actions_client.list()
+                action_found = self._entry_in_collection(
+                    action_name, actions, keys=("name", "action", "slug", "id")
+                )
+                if not action_found:
+                    issues.append("Action introuvable pour ce connecteur")
+            except Exception as exc:  # pragma: no cover
+                issues.append(f"Impossible d'interroger les actions: {exc}")
+        else:
+            issues.append("La méthode actions.list() n'est pas disponible")
+
+        available = connector_found and action_found
+        reason = "; ".join(dict.fromkeys(issues)) if issues else None
+        return available, reason
+
+    @staticmethod
+    def _entry_in_collection(expected: str, collection: Any, keys: tuple[str, ...]) -> bool:
+        """Détermine si une valeur correspondante est présente dans une collection."""
+
+        if not collection:
+            return False
+
+        expected_lower = expected.lower()
+        for item in ComposioClient._normalize_collection(collection):
+            for value in ComposioClient._extract_values(item, keys):
+                value_lower = value.lower()
+                if (
+                    value_lower == expected_lower
+                    or value_lower.endswith(expected_lower)
+                    or expected_lower in value_lower
+                ):
+                    return True
+        return False
+
+    @staticmethod
+    def _normalize_collection(collection: Any) -> List[Any]:
+        """Aplati différentes structures renvoyées par le SDK Composio."""
+
+        if isinstance(collection, dict):
+            if "items" in collection and isinstance(collection["items"], list):
+                return list(collection["items"])
+            return [collection]
+        if isinstance(collection, (list, tuple, set)):
+            return list(collection)
+        return [collection]
+
+    @staticmethod
+    def _extract_values(item: Any, keys: tuple[str, ...]) -> List[str]:
+        """Récupère les valeurs texte pertinentes d'un élément de collection."""
+
+        values: List[str] = []
+        if isinstance(item, str):
+            values.append(item)
+            return values
+
+        if isinstance(item, dict):
+            for key in keys:
+                value = item.get(key)
+                if isinstance(value, str):
+                    values.append(value)
+            return values
+
+        for key in keys:
+            value = getattr(item, key, None)
+            if isinstance(value, str):
+                values.append(value)
+        return values
+
+    def dispatch_reply(
+        self,
+        channel: SupportChannel,
+        message: str,
+        customer_handle: Optional[str],
+        thread_id: Optional[str] = None,
+        subject: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Envoie la réponse générée sur le canal approprié."""
+
+        connector_spec = self.CHANNEL_CONNECTORS.get(channel)
+        if connector_spec is None:
+            return {
+                "status": "unsupported",
+                "reason": f"Canal {channel.value} non configuré pour la diffusion",
+            }
+
+        if not customer_handle:
+            return {
+                "status": "missing-handle",
+                "reason": "Aucun identifiant client fourni pour l'envoi",
+                "connector": connector_spec["connector"],
+            }
+
+        payload: Dict[str, Any] = {
+            connector_spec["handle_param"]: customer_handle,
+            "message": message,
+        }
+        if thread_id:
+            payload["thread_id"] = thread_id
+        if subject and channel in {SupportChannel.gmail, SupportChannel.outlook}:
+            payload.setdefault("subject", subject)
+
+        if not self._client:
+            logger.debug(
+                "Diffusion simulée sur %s pour %s", connector_spec["connector"], customer_handle
+            )
+            return {
+                "status": "simulated",
+                "connector": connector_spec["connector"],
+                "payload": payload,
+            }
+
+        try:
+            logger.info(
+                "Envoi via Composio connector=%s action=%s",
+                connector_spec["connector"],
+                connector_spec["action"],
+            )
+            result = self._client.actions.execute(  # type: ignore[union-attr]
+                connector=connector_spec["connector"],
+                action=connector_spec["action"],
+                params=payload,
+            )
+            return {
+                "status": "sent",
+                "connector": connector_spec["connector"],
+                "result": result,
+            }
+        except Exception as exc:  # pragma: no cover
+            logger.error("Erreur lors de l'envoi via Composio: %s", exc)
+            return {
+                "status": "error",
+                "connector": connector_spec["connector"],
+                "error": str(exc),
+            }
+
+
+__all__ = ["ComposioClient"]

--- a/src/mcp_customer_service/config.py
+++ b/src/mcp_customer_service/config.py
@@ -1,0 +1,62 @@
+"""Gestion de la configuration pour le serveur MCP."""
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from typing import Optional
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    """Paramètres du serveur MCP."""
+
+    openai_api_key: str = Field(
+        default="",
+        description="Clé API OpenAI utilisée pour appeler ChatGPT.",
+        env="OPENAI_API_KEY",
+    )
+    composio_api_key: str = Field(
+        default="",
+        description="Clé API Composio pour orchestrer les intégrations.",
+        env="COMPOSIO_API_KEY",
+    )
+    default_model: str = Field(
+        default="gpt-4o-mini",
+        env="DEFAULT_MODEL",
+        description="Modèle OpenAI utilisé par défaut pour générer les réponses.",
+    )
+    max_history_messages: int = Field(
+        default=6,
+        ge=1,
+        description="Nombre de messages précédents envoyés au modèle pour le contexte.",
+    )
+    enable_debug_traces: bool = Field(
+        default=False,
+        env="ENABLE_DEBUG_TRACES",
+        description="Active les traces détaillées dans les réponses MCP.",
+    )
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+
+    @validator("openai_api_key", "composio_api_key", pre=True)
+    def _clean_api_keys(cls, value: Optional[str]) -> str:
+        if value is None:
+            return ""
+        return value.strip()
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Retourne les paramètres mis en cache."""
+
+    settings = Settings()
+    logging.getLogger(__name__).debug("Configuration chargée: %s", settings.dict())
+    return settings
+
+
+__all__ = ["Settings", "get_settings"]

--- a/src/mcp_customer_service/config.py
+++ b/src/mcp_customer_service/config.py
@@ -22,6 +22,11 @@ class Settings(BaseSettings):
         description="Clé API Composio pour orchestrer les intégrations.",
         env="COMPOSIO_API_KEY",
     )
+    telegram_bot_token: str = Field(
+        default="",
+        description="Jeton d'accès Telegram pour lancer le bot de test.",
+        env="TELEGRAM_BOT_TOKEN",
+    )
     default_model: str = Field(
         default="gpt-4o-mini",
         env="DEFAULT_MODEL",
@@ -43,7 +48,7 @@ class Settings(BaseSettings):
         env_file_encoding = "utf-8"
         case_sensitive = False
 
-    @validator("openai_api_key", "composio_api_key", pre=True)
+    @validator("openai_api_key", "composio_api_key", "telegram_bot_token", pre=True)
     def _clean_api_keys(cls, value: Optional[str]) -> str:
         if value is None:
             return ""

--- a/src/mcp_customer_service/llm.py
+++ b/src/mcp_customer_service/llm.py
@@ -1,0 +1,54 @@
+"""Client LLM basé sur l'API OpenAI."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List
+
+from openai import OpenAI
+
+from .config import Settings, get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class ChatGPTClient:
+    """Encapsulation des appels au modèle OpenAI ChatGPT."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        if not self.settings.openai_api_key:
+            logger.warning(
+                "Aucune clé API OpenAI détectée. Le serveur fonctionnera en mode simulation."
+            )
+            self._client: OpenAI | None = None
+        else:
+            self._client = OpenAI(api_key=self.settings.openai_api_key)
+
+    def generate_reply(self, messages: Iterable[dict]) -> str:
+        """Génère une réponse en utilisant le modèle spécifié."""
+
+        message_list: List[dict] = list(messages)
+        if not self._client:
+            logger.debug("Génération simulée pour %d messages", len(message_list))
+            return (
+                "[SIMULATION] Merci pour votre message. Un conseiller vous répondra "
+                "rapidement."
+            )
+
+        logger.debug(
+            "Envoi de %d messages au modèle %s",
+            len(message_list),
+            self.settings.default_model,
+        )
+        response = self._client.chat.completions.create(
+            model=self.settings.default_model,
+            messages=message_list,
+            temperature=0.2,
+        )
+        choice = response.choices[0]
+        reply = choice.message.content or ""
+        logger.info("Réponse générée (fin=%s) : %s", choice.finish_reason, reply)
+        return reply
+
+
+__all__ = ["ChatGPTClient"]

--- a/src/mcp_customer_service/server.py
+++ b/src/mcp_customer_service/server.py
@@ -1,0 +1,176 @@
+"""Serveur MCP représentant un agent IA de relation client multicanal."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Literal
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from .channels import AgentReply, CustomerPayload, SupportChannel, build_llm_messages
+from .composio_client import ComposioClient
+from .config import Settings, get_settings
+from .llm import ChatGPTClient
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class MCPCommand(BaseModel):
+    """Commande conforme au protocole MCP."""
+
+    command: str = Field(..., description="Nom de la commande MCP demandée")
+    payload: CustomerPayload
+
+
+class MCPEnvelope(BaseModel):
+    """Enveloppe standardisée pour les réponses."""
+
+    status: Literal["ok", "error"]
+    data: Dict[str, Any] | None = None
+    diagnostics: List[str] = Field(default_factory=list)
+
+
+class MultiChannelCustomerAgent:
+    """Agent orchestrant l'accès au LLM et à Composio."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self.llm = ChatGPTClient(self.settings)
+        self.composio = ComposioClient(self.settings)
+
+    def handle_reply(self, payload: CustomerPayload) -> AgentReply:
+        context = self.composio.enrich_context(
+            channel=payload.channel.value,
+            customer_id=payload.customer_id,
+            message=payload.message,
+        )
+        messages = build_llm_messages(payload, context.get("insights", []))
+        reply = self.llm.generate_reply(messages)
+        actions = self._suggest_actions(payload, context)
+        delivery = self._dispatch_reply(payload, reply)
+        if delivery:
+            context.setdefault("delivery", delivery)
+        return AgentReply(channel=payload.channel, reply=reply, actions=actions, context=context)
+
+    @staticmethod
+    def _suggest_actions(payload: CustomerPayload, context: Dict[str, Any]) -> List[str]:
+        """Propose quelques actions suivant le contexte."""
+
+        actions: List[str] = []
+        sentiment = payload.metadata.get("sentiment")
+        urgency = payload.metadata.get("urgency")
+        if urgency == "high":
+            actions.append("Escalader vers un superviseur humain")
+        if payload.channel in {SupportChannel.gmail, SupportChannel.outlook}:
+            actions.append("Joindre un suivi par email avec le récapitulatif")
+        if payload.channel == SupportChannel.whatsapp:
+            actions.append("Proposer une confirmation instantanée sur WhatsApp")
+        if payload.channel == SupportChannel.linkedin:
+            actions.append("Partager des ressources professionnelles adaptées sur LinkedIn")
+        if payload.channel == SupportChannel.instagram:
+            actions.append("Inclure un visuel ou une story pour renforcer le message")
+        if sentiment == "negative":
+            actions.append("Offrir un geste commercial")
+        if not actions:
+            actions.append("Consigner la conversation dans le CRM")
+        return actions
+
+    def _dispatch_reply(self, payload: CustomerPayload, reply: str) -> Dict[str, Any] | None:
+        """Envoie la réponse sur le canal demandé via Composio."""
+
+        customer_handle = self._resolve_destination(payload)
+        subject = payload.metadata.get("subject")
+        delivery = self.composio.dispatch_reply(
+            channel=payload.channel,
+            message=reply,
+            customer_handle=customer_handle,
+            thread_id=payload.thread_id,
+            subject=subject,
+        )
+        return delivery
+
+    @staticmethod
+    def _resolve_destination(payload: CustomerPayload) -> str | None:
+        """Détermine l'identifiant du client en fonction du canal."""
+
+        metadata = payload.metadata
+        if payload.channel == SupportChannel.whatsapp:
+            return metadata.get("whatsapp_number") or metadata.get("phone_number")
+        if payload.channel == SupportChannel.linkedin:
+            return metadata.get("linkedin_profile") or metadata.get("profile_url")
+        if payload.channel == SupportChannel.gmail:
+            return metadata.get("gmail_address") or metadata.get("email")
+        if payload.channel == SupportChannel.outlook:
+            return metadata.get("outlook_address") or metadata.get("email")
+        if payload.channel == SupportChannel.instagram:
+            return metadata.get("instagram_handle") or metadata.get("username")
+        return None
+
+
+def build_app(settings: Settings | None = None) -> FastAPI:
+    """Construit une application FastAPI exposant l'agent MCP."""
+
+    settings = settings or get_settings()
+    agent = MultiChannelCustomerAgent(settings)
+    app = FastAPI(
+        title="Infinity MCP Customer Service Agent",
+        version="0.1.0",
+        description="Agent multicanal basé sur ChatGPT et Composio.",
+    )
+
+    @app.get("/health", tags=["health"])
+    async def health_check() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/mcp/v1/metadata", tags=["mcp"])
+    async def metadata() -> Dict[str, Any]:
+        return {
+            "name": "infinity-customer-agent",
+            "version": "0.1.0",
+            "capabilities": ["customer-support", "multichannel", "knowledge-integration"],
+            "llm_model": settings.default_model,
+            "connectors": agent.composio.list_available_tools(),
+        }
+
+    @app.get("/mcp/v1/connectors", tags=["mcp"])
+    async def connectors() -> Dict[str, Any]:
+        """Expose l'état des connecteurs Composio configurés."""
+
+        return agent.composio.list_available_tools()
+
+    @app.post("/mcp/v1/execute", response_model=MCPEnvelope, tags=["mcp"])
+    async def execute(command: MCPCommand) -> MCPEnvelope:
+        logger.info("Commande MCP reçue: %s", command.command)
+        if command.command != "customer-agent.reply":
+            raise HTTPException(status_code=400, detail="Commande MCP inconnue")
+
+        reply = agent.handle_reply(command.payload)
+        envelope = MCPEnvelope(
+            status="ok",
+            data={"reply": reply.dict()},
+        )
+        if settings.enable_debug_traces:
+            envelope.diagnostics.append("Messages envoyés au LLM: %d" % len(command.payload.history))
+        return envelope
+
+    @app.exception_handler(Exception)
+    async def handle_exception(_: Request, exc: Exception) -> JSONResponse:
+        logger.exception("Erreur serveur", exc_info=exc)
+        return JSONResponse(
+            status_code=500,
+            content=MCPEnvelope(status="error", diagnostics=[str(exc)]).dict(),
+        )
+
+    return app
+
+
+def main() -> None:  # pragma: no cover - point d'entrée
+    import uvicorn
+
+    uvicorn.run("mcp_customer_service.server:build_app", factory=True, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/mcp_customer_service/telegram_bot.py
+++ b/src/mcp_customer_service/telegram_bot.py
@@ -1,0 +1,287 @@
+"""Bot Telegram permettant de piloter l'agent MCP en conditions réelles."""
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Dict, List, Optional
+
+from .channels import ConversationMessage, CustomerPayload, SupportChannel
+from .config import Settings, get_settings
+from .server import MultiChannelCustomerAgent
+
+try:  # pragma: no cover - dépendance optionnelle
+    from telegram import Update
+    from telegram.constants import ParseMode
+    from telegram.ext import (
+        Application,
+        CommandHandler,
+        ContextTypes,
+        MessageHandler,
+        filters,
+    )
+except Exception as exc:  # pragma: no cover - gestion douce des imports
+    Update = None  # type: ignore[assignment]
+    ParseMode = None  # type: ignore[assignment]
+    Application = None  # type: ignore[assignment]
+    CommandHandler = None  # type: ignore[assignment]
+    ContextTypes = None  # type: ignore[assignment]
+    MessageHandler = None  # type: ignore[assignment]
+    filters = None  # type: ignore[assignment]
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionState:
+    """Historique et configuration spécifique à un utilisateur Telegram."""
+
+    channel: SupportChannel = SupportChannel.gmail
+    history: Deque[ConversationMessage] = field(
+        default_factory=lambda: deque(maxlen=10)
+    )
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def to_history(self) -> List[ConversationMessage]:
+        return list(self.history)
+
+
+class TelegramCustomerAgentBot:
+    """Wrappe python-telegram-bot pour interroger l'agent MCP."""
+
+    def __init__(self, token: str, settings: Optional[Settings] = None) -> None:
+        if Application is None:  # pragma: no cover - dépend de l'installation locale
+            raise RuntimeError(
+                "python-telegram-bot n'est pas installé: %s" % (_IMPORT_ERROR,)
+            )
+
+        self.settings = settings or get_settings()
+        self.agent = MultiChannelCustomerAgent(self.settings)
+        self.token = token
+        self.sessions: Dict[int, SessionState] = {}
+        self.application = Application.builder().token(token).build()
+
+        self.application.add_handler(CommandHandler("start", self.cmd_start))
+        self.application.add_handler(CommandHandler("help", self.cmd_help))
+        self.application.add_handler(CommandHandler("channel", self.cmd_channel))
+        self.application.add_handler(CommandHandler("connect", self.cmd_connect))
+        self.application.add_handler(CommandHandler("installations", self.cmd_installations))
+        self.application.add_handler(CommandHandler("status", self.cmd_status))
+        self.application.add_handler(CommandHandler("setmeta", self.cmd_setmeta))
+        self.application.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, self.handle_message)
+        )
+
+    # ------------------------------------------------------------------
+    # Gestion des commandes
+    async def cmd_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        await update.message.reply_text(
+            (
+                "Bonjour! Je suis l'agent client Infinity. "
+                "Utilisez /channel <canal> pour choisir le canal cible (whatsapp, "
+                "linkedin, gmail, outlook, instagram).\n"
+                "Partagez ensuite un message et je vous répondrai comme si la "
+                "conversation se déroulait sur ce canal.\n"
+                "Commandes utiles :\n"
+                "• /connect <canal> : obtenir un lien Composio pour connecter votre compte\n"
+                "• /installations : voir les connexions existantes\n"
+                "• /status : vérifier l'état des connecteurs\n"
+                "• /setmeta <clé> <valeur> : fournir un identifiant client (ex: gmail_address)"
+            )
+        )
+
+    async def cmd_help(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        await self.cmd_start(update, context)
+
+    async def cmd_channel(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not context.args:
+            await update.message.reply_text(
+                "Veuillez préciser un canal: whatsapp, linkedin, gmail, outlook ou instagram."
+            )
+            return
+
+        channel_name = context.args[0].lower()
+        try:
+            channel = SupportChannel(channel_name)
+        except ValueError:
+            await update.message.reply_text(
+                f"Canal inconnu '{channel_name}'. Choisissez parmi: "
+                f"{', '.join(c.value for c in SupportChannel)}"
+            )
+            return
+
+        state = self._get_state(update.effective_chat.id)
+        state.channel = channel
+        await update.message.reply_text(
+            f"Canal par défaut défini sur {channel.value}."
+        )
+
+    async def cmd_connect(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not context.args:
+            await update.message.reply_text(
+                "Usage : /connect <canal>."
+            )
+            return
+
+        channel_name = context.args[0].lower()
+        try:
+            channel = SupportChannel(channel_name)
+        except ValueError:
+            await update.message.reply_text(
+                f"Canal inconnu '{channel_name}'."
+            )
+            return
+
+        user_id = str(update.effective_user.id)
+        link_info = self.agent.composio.generate_installation_link(
+            channel=channel, external_user_id=user_id
+        )
+
+        if link_info.get("status") == "error":
+            await update.message.reply_text(
+                f"Impossible de générer le lien: {link_info.get('reason', 'erreur inconnue')}"
+            )
+            return
+
+        url = link_info.get("url") or link_info.get("authorization_url")
+        if not url:
+            await update.message.reply_text(
+                "Lien reçu mais aucune URL n'est disponible. Vérifiez votre configuration Composio."
+            )
+            return
+
+        await update.message.reply_text(
+            (
+                f"Connectez votre compte {channel.value} via Composio :\n{url}\n"
+                "Une fois l'installation terminée, utilisez /installations pour vérifier."
+            ),
+            disable_web_page_preview=False,
+        )
+
+    async def cmd_installations(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user_id = str(update.effective_user.id)
+        info = self.agent.composio.list_user_installations(user_id)
+
+        if info.get("status") == "error":
+            await update.message.reply_text(
+                f"Erreur lors de la récupération des installations: {info.get('reason', 'inconnue')}"
+            )
+            return
+
+        installations = info.get("installations", [])
+        if not installations:
+            await update.message.reply_text("Aucune installation Composio détectée pour le moment.")
+            return
+
+        lines = ["Installations Composio associées à votre compte:"]
+        for idx, item in enumerate(installations, start=1):
+            connector = item.get("connector") or item.get("integration") or item.get("name")
+            status = item.get("status") or item.get("state")
+            lines.append(f"{idx}. {connector or 'inconnu'} — {status or 'actif'}")
+        await update.message.reply_text("\n".join(lines))
+
+    async def cmd_status(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        info = self.agent.composio.list_available_tools()
+        lines = [f"Mode Composio: {info.get('mode')}" , "Connecteurs:" ]
+        for entry in info.get("connectors", []):
+            status = "✅" if entry.get("available") else "❌"
+            reason = entry.get("reason")
+            line = f"{status} {entry['channel']} → {entry['connector']}/{entry['action']}"
+            if reason:
+                line += f" ({reason})"
+            lines.append(line)
+        await update.message.reply_text("\n".join(lines))
+
+    async def cmd_setmeta(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if len(context.args) < 2:
+            await update.message.reply_text(
+                "Usage : /setmeta <clé> <valeur>. Exemple: /setmeta gmail_address client@example.com"
+            )
+            return
+
+        key = context.args[0]
+        value = " ".join(context.args[1:])
+        state = self._get_state(update.effective_chat.id)
+        state.metadata[key] = value
+        await update.message.reply_text(
+            f"Métadonnée '{key}' enregistrée pour les prochaines réponses."
+        )
+
+    # ------------------------------------------------------------------
+    # Messages utilisateurs
+    async def handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        message = update.message
+        if message is None or message.text is None:
+            return
+
+        state = self._get_state(update.effective_chat.id)
+        state.history.append(
+            ConversationMessage(role="user", content=message.text)
+        )
+
+        payload = CustomerPayload(
+            channel=state.channel,
+            customer_id=str(update.effective_user.id),
+            thread_id=str(update.effective_chat.id),
+            message=message.text,
+            history=state.to_history(),
+            metadata=dict(state.metadata),
+        )
+
+        reply = self.agent.handle_reply(payload)
+
+        state.history.append(
+            ConversationMessage(role="assistant", content=reply.reply)
+        )
+
+        await message.reply_text(reply.reply)
+
+        if reply.actions:
+            actions_text = "\n".join(f"• {action}" for action in reply.actions)
+            await message.reply_text(
+                f"Actions suggérées:\n{actions_text}",
+                parse_mode=ParseMode.MARKDOWN if ParseMode else None,
+            )
+
+        delivery = reply.context.get("delivery") if isinstance(reply.context, dict) else None
+        if isinstance(delivery, dict) and delivery.get("status") not in {None, "missing-handle"}:
+            summary = delivery.get("status")
+            connector = delivery.get("connector")
+            await message.reply_text(
+                f"Statut d'envoi via Composio: {summary} ({connector})"
+            )
+
+    # ------------------------------------------------------------------
+    def _get_state(self, chat_id: int) -> SessionState:
+        if chat_id not in self.sessions:
+            self.sessions[chat_id] = SessionState()
+        return self.sessions[chat_id]
+
+    def run(self) -> None:
+        """Démarre le bot en mode polling."""
+
+        logger.info("Démarrage du bot Telegram pour l'agent client")
+        self.application.run_polling()
+
+
+def main() -> None:  # pragma: no cover - point d'entrée pratique
+    settings = get_settings()
+    token = settings.telegram_bot_token
+    if not token:
+        raise RuntimeError(
+            "TELEGRAM_BOT_TOKEN n'est pas défini dans l'environnement."
+        )
+
+    bot = TelegramCustomerAgentBot(token=token, settings=settings)
+    bot.run()
+
+
+__all__ = ["TelegramCustomerAgentBot", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_composio_client.py
+++ b/tests/test_composio_client.py
@@ -16,8 +16,9 @@ sys.modules.setdefault("mcp_customer_service", package)
 
 
 class _SettingsStub:
-    def __init__(self, composio_api_key: str = "", **_: str) -> None:
+    def __init__(self, composio_api_key: str = "", telegram_bot_token: str = "", **_: str) -> None:
         self.composio_api_key = composio_api_key
+        self.telegram_bot_token = telegram_bot_token
 
 
 def _get_settings_stub() -> _SettingsStub:
@@ -66,6 +67,10 @@ composio_module = _load_module(
 )
 
 ComposioClient = getattr(composio_module, "ComposioClient")
+SupportChannel = getattr(_load_module(
+    "mcp_customer_service.channels",
+    "src/mcp_customer_service/channels.py",
+), "SupportChannel")
 Settings = _SettingsStub
 
 
@@ -88,6 +93,21 @@ class _DummyActions:
         for values in self._mapping.values():
             merged.extend(values)
         return merged
+
+
+class _DummyInstallations:
+    def __init__(self) -> None:
+        self.created_payloads: List[Dict[str, str]] = []
+
+    def create_installation_link(self, **payload):  # pragma: no cover - simple stub
+        self.created_payloads.append(payload)
+        return {"url": "https://composio.test/install", "connector": payload.get("connector")}
+
+    def list(self, **_kwargs):  # pragma: no cover - simple stub
+        return [
+            {"connector": "gmail", "status": "installed"},
+            {"connector": "whatsapp", "status": "pending"},
+        ]
 
 
 def test_list_available_tools_simulated_mode():
@@ -122,6 +142,7 @@ def test_list_available_tools_live_mode():
                     "linkedin": [{"name": "send_message"}],
                 }
             ),
+            "installations": _DummyInstallations(),
         },
     )()
 
@@ -133,3 +154,59 @@ def test_list_available_tools_live_mode():
     connectors = {entry["channel"]: entry for entry in info["connectors"]}
     assert connectors["whatsapp"]["available"] is True
     assert connectors["linkedin"]["available"] is True
+
+
+def test_generate_installation_link_simulated_mode():
+    settings = Settings(composio_api_key="")
+    client = ComposioClient(settings)
+
+    link = client.generate_installation_link(SupportChannel.gmail, external_user_id="42")
+
+    assert link["status"] == "simulated"
+    assert "url" in link
+
+
+def test_generate_installation_link_live_mode():
+    settings = Settings(composio_api_key="dummy")
+    client = ComposioClient(settings)
+
+    installations = _DummyInstallations()
+    dummy_client = type(
+        "DummyClient",
+        (),
+        {
+            "connectors": _DummyConnectors([{"slug": "gmail"}]),
+            "actions": _DummyActions({"gmail": [{"name": "send_email"}]}),
+            "installations": installations,
+        },
+    )()
+
+    client._client = dummy_client  # type: ignore[attr-defined]
+
+    link = client.generate_installation_link(SupportChannel.gmail, external_user_id="100")
+
+    assert link["status"] == "live"
+    assert link.get("url") == "https://composio.test/install"
+    assert installations.created_payloads[0]["connector"] == "gmail"
+
+
+def test_list_user_installations_live_mode():
+    settings = Settings(composio_api_key="dummy")
+    client = ComposioClient(settings)
+
+    dummy_client = type(
+        "DummyClient",
+        (),
+        {
+            "connectors": _DummyConnectors([{"slug": "gmail"}]),
+            "actions": _DummyActions({"gmail": [{"name": "send_email"}]}),
+            "installations": _DummyInstallations(),
+        },
+    )()
+
+    client._client = dummy_client  # type: ignore[attr-defined]
+
+    info = client.list_user_installations("100")
+
+    assert info["status"] == "live"
+    assert len(info["installations"]) == 2

--- a/tests/test_composio_client.py
+++ b/tests/test_composio_client.py
@@ -1,0 +1,135 @@
+"""Tests autour du client Composio."""
+from __future__ import annotations
+
+from importlib import util as importlib_util
+from pathlib import Path
+from typing import Dict, List
+import sys
+import types
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_PATH = PROJECT_ROOT / "src" / "mcp_customer_service"
+
+package = types.ModuleType("mcp_customer_service")
+package.__path__ = [str(PACKAGE_PATH)]
+sys.modules.setdefault("mcp_customer_service", package)
+
+
+class _SettingsStub:
+    def __init__(self, composio_api_key: str = "", **_: str) -> None:
+        self.composio_api_key = composio_api_key
+
+
+def _get_settings_stub() -> _SettingsStub:
+    return _SettingsStub()
+
+
+config_stub = types.ModuleType("mcp_customer_service.config")
+config_stub.Settings = _SettingsStub
+config_stub.get_settings = _get_settings_stub
+sys.modules["mcp_customer_service.config"] = config_stub
+
+
+class _BaseModelStub:
+    def __init__(self, **data):
+        for key, value in data.items():
+            setattr(self, key, value)
+
+    def dict(self, **_: str):
+        return dict(self.__dict__)
+
+
+def _field_stub(*_args, default=None, default_factory=None, **_kwargs):
+    if default_factory is not None:
+        return default_factory()
+    return default
+
+
+pydantic_stub = types.ModuleType("pydantic")
+pydantic_stub.BaseModel = _BaseModelStub
+pydantic_stub.Field = _field_stub
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+
+def _load_module(module_name: str, relative_path: str):
+    module_path = PROJECT_ROOT / relative_path
+    spec = importlib_util.spec_from_file_location(module_name, module_path)
+    module = importlib_util.module_from_spec(spec)  # type: ignore[arg-type]
+    assert spec and spec.loader  # nosec - vérification simple pour les tests
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+composio_module = _load_module(
+    "mcp_customer_service.composio_client",
+    "src/mcp_customer_service/composio_client.py",
+)
+
+ComposioClient = getattr(composio_module, "ComposioClient")
+Settings = _SettingsStub
+
+
+class _DummyConnectors:
+    def __init__(self, items: List[Dict[str, str]]) -> None:
+        self._items = items
+
+    def list(self):  # pragma: no cover - méthode simple
+        return {"items": self._items}
+
+
+class _DummyActions:
+    def __init__(self, mapping: Dict[str, List[Dict[str, str]]]) -> None:
+        self._mapping = mapping
+
+    def list(self, connector: str | None = None):  # pragma: no cover - méthode simple
+        if connector:
+            return self._mapping.get(connector, [])
+        merged: List[Dict[str, str]] = []
+        for values in self._mapping.values():
+            merged.extend(values)
+        return merged
+
+
+def test_list_available_tools_simulated_mode():
+    settings = Settings(composio_api_key="")
+    client = ComposioClient(settings)
+
+    info = client.list_available_tools()
+
+    assert info["mode"] == "simulated"
+    connectors = {entry["channel"]: entry for entry in info["connectors"]}
+    assert connectors["whatsapp"]["available"] is False
+    assert "reason" in connectors["whatsapp"]
+
+
+def test_list_available_tools_live_mode():
+    settings = Settings(composio_api_key="dummy")
+    client = ComposioClient(settings)
+
+    dummy_client = type(
+        "DummyClient",
+        (),
+        {
+            "connectors": _DummyConnectors(
+                [
+                    {"slug": "whatsapp"},
+                    {"slug": "linkedin"},
+                ]
+            ),
+            "actions": _DummyActions(
+                {
+                    "whatsapp": [{"name": "send_message"}],
+                    "linkedin": [{"name": "send_message"}],
+                }
+            ),
+        },
+    )()
+
+    client._client = dummy_client  # type: ignore[attr-defined]
+
+    info = client.list_available_tools()
+
+    assert info["mode"] == "live"
+    connectors = {entry["channel"]: entry for entry in info["connectors"]}
+    assert connectors["whatsapp"]["available"] is True
+    assert connectors["linkedin"]["available"] is True


### PR DESCRIPTION
## Summary
- add Composio connector inspection utilities that report availability and diagnostics per channel
- surface connector status through the MCP metadata payload and a dedicated `/mcp/v1/connectors` endpoint, plus docs on verifying access
- cover the inspection logic with tests that exercise simulated and live connector scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fad8fc8604832da978f56f4e2c8e72